### PR TITLE
Feat/orders

### DIFF
--- a/http/item.http
+++ b/http/item.http
@@ -2,6 +2,25 @@
 @popupId = 31
 @itemId = 3
 
+### 호스트 로그인
+POST http://localhost:8081/api/v1/login
+Content-Type: application/json
+
+{
+  "username": "{{username}}",
+  "password": "{{password}}"
+}
+
+> {%
+  client.global.set("Authorization", response.headers.valueOf("Authorization"));
+  client.global.set("refresh_token",
+      response.headers.valueOf("Set-Cookie").split(";")[0].split("=")[1]);
+  client.log("Authorization : " + client.global.get("Authorization"))
+  client.log("refresh_token : " + client.global.get("refresh_token"))
+
+  client.global.set("Cookie", response.headers.valueOf("Set-Cookie"));
+%}
+
 ### 굿즈 상품 등록
 POST http://localhost:8081/api/v1/popups/{{popupId}}/items
 Authorization: {{Authorization}}

--- a/src/main/java/com/sparta/ezpzhost/common/exception/ErrorType.java
+++ b/src/main/java/com/sparta/ezpzhost/common/exception/ErrorType.java
@@ -1,11 +1,11 @@
 package com.sparta.ezpzhost.common.exception;
 
+import static com.sparta.ezpzhost.common.resolver.CustomPageableHandlerMethodArgumentResolver.MAX_PAGE_SIZE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-
-import static com.sparta.ezpzhost.common.resolver.CustomPageableHandlerMethodArgumentResolver.MAX_PAGE_SIZE;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Getter
 @AllArgsConstructor
@@ -45,6 +45,7 @@ public enum ErrorType {
 
     // Order
     INVALID_ORDER_SORT_CONDITION(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 정렬 조건입니다."),
+    ORDER_NOT_FOUND_OR_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "해당 주문이 존재하지 않거나, 상품에 대한 권한이 없습니다."),
 
     // Item
     DUPLICATED_ITEM_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 굿즈명입니다."),
@@ -56,12 +57,12 @@ public enum ErrorType {
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예약이 존재하지 않습니다."),
     INVALID_DATE_TIME(HttpStatus.BAD_REQUEST, "예약을 등록할 수 있는 날짜, 시간이 아닙니다."),
     SLOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 예약 슬롯이 존재합니다."),
-    
+
 
     // Page
     INVALID_PAGE(HttpStatus.BAD_REQUEST, "페이지 번호가 올바르지 않습니다."),
-    NOT_FOUND_PAGE(HttpStatus.NOT_FOUND, "페이지가 존재하지 않습니다.")
-    
+    NOT_FOUND_PAGE(HttpStatus.NOT_FOUND, "페이지가 존재하지 않습니다."),
+
     //
 
     ;

--- a/src/main/java/com/sparta/ezpzhost/common/exception/ErrorType.java
+++ b/src/main/java/com/sparta/ezpzhost/common/exception/ErrorType.java
@@ -44,6 +44,7 @@ public enum ErrorType {
     IMAGE_COUNT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "추가 사진은 최소 1개, 최대 3개까지 등록 가능합니다"),
 
     // Order
+    INVALID_ORDER_SORT_CONDITION(HttpStatus.BAD_REQUEST, "유효하지 않은 주문 정렬 조건입니다."),
 
     // Item
     DUPLICATED_ITEM_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 굿즈명입니다."),

--- a/src/main/java/com/sparta/ezpzhost/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/item/repository/ItemRepository.java
@@ -2,12 +2,17 @@ package com.sparta.ezpzhost.domain.item.repository;
 
 import com.sparta.ezpzhost.domain.host.entity.Host;
 import com.sparta.ezpzhost.domain.item.entity.Item;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
+
     boolean existsByName(String name);
 
     Optional<Item> findByIdAndPopup_Host(Long itemId, Host host);
+
+    @Query("SELECT COUNT(i) > 0 FROM Item i JOIN i.popup p JOIN p.host h WHERE i.id = :itemId AND h.id = :hostId")
+    boolean isItemSoldByHost(@Param("itemId") Long itemId, @Param("hostId") Long hostId);
 }

--- a/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
@@ -34,7 +34,7 @@ public class OrderController {
      * @return 조건별 주문 목록
      */
     @GetMapping
-    public ResponseEntity<CommonResponse<?>> findOrdersAllByStatus(
+    public ResponseEntity<CommonResponse<?>> findAllOrders(
             Pageable pageable,
             @RequestParam(defaultValue = "all") String searchType,
             @RequestParam(defaultValue = "-1") Long itemId,
@@ -43,7 +43,7 @@ public class OrderController {
 
         OrderCondition cond = OrderCondition.of(searchType, itemId, orderStatus);
         return getResponseEntity(
-                orderService.findOrdersAllByStatus(cond, pageable, userDetails.getHost()),
+                orderService.findAllOrders(cond, pageable, userDetails.getHost()),
                 "주문 목록 조회 성공");
 
     }

--- a/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
@@ -1,0 +1,49 @@
+package com.sparta.ezpzhost.domain.order.controller;
+
+import static com.sparta.ezpzhost.common.util.ControllerUtil.getResponseEntity;
+
+import com.sparta.ezpzhost.common.dto.CommonResponse;
+import com.sparta.ezpzhost.common.security.UserDetailsImpl;
+import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
+import com.sparta.ezpzhost.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 목록 조회
+     *
+     * @param pageable    페이지네이션 조건
+     * @param searchType  조건별 조회 기준
+     * @param itemId      상품별 조회할 때 조회할 상품 Id
+     * @param orderStatus 주문 상태별 조회할 때 조회할 주문 상태
+     * @param userDetails 사용자 정보
+     * @return 조건별 주문 목록
+     */
+    @GetMapping
+    public ResponseEntity<CommonResponse<?>> findOrdersAllByStatus(
+            Pageable pageable,
+            @RequestParam(defaultValue = "all") String searchType,
+            @RequestParam(defaultValue = "-1") Long itemId,
+            @RequestParam(defaultValue = "all") String orderStatus,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        OrderCondition cond = OrderCondition.of(searchType, itemId, orderStatus);
+        return getResponseEntity(
+                orderService.findOrdersAllByStatus(cond, pageable, userDetails.getHost()),
+                "주문 목록 조회 성공");
+
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/controller/OrderController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +46,20 @@ public class OrderController {
                 orderService.findOrdersAllByStatus(cond, pageable, userDetails.getHost()),
                 "주문 목록 조회 성공");
 
+    }
+
+    /**
+     * 주문 상세 조회
+     *
+     * @param orderId     조회할 주문 id
+     * @param userDetails 사용자 정보
+     * @return 주문 상세 조회 데이터
+     */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<CommonResponse<?>> findOrder(
+            @PathVariable Long orderId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return getResponseEntity(orderService.findOrder(orderId, userDetails.getHost()),
+                "주문 상세 조회 성공");
     }
 }

--- a/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderCondition.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderCondition.java
@@ -1,0 +1,44 @@
+package com.sparta.ezpzhost.domain.order.dto;
+
+import com.sparta.ezpzhost.common.exception.CustomException;
+import com.sparta.ezpzhost.common.exception.ErrorType;
+import com.sparta.ezpzhost.domain.order.enums.OrderSearchType;
+import com.sparta.ezpzhost.domain.order.enums.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Setter
+public class OrderCondition {
+
+    private final OrderSearchType searchType;
+    private final Long itemId;
+    private final OrderStatus orderStatus;
+
+    public OrderCondition(OrderSearchType searchType, Long itemId, OrderStatus orderStatus) {
+        this.searchType = searchType;
+        this.itemId = itemId;
+        this.orderStatus = orderStatus;
+    }
+
+    public static OrderCondition of(String searchType, Long itemId, String orderStatus) {
+        if (!StringUtils.hasText(searchType) || !OrderSearchType.isValid(searchType)) {
+            throw new CustomException(ErrorType.INVALID_ORDER_SORT_CONDITION);
+        }
+        OrderSearchType type = OrderSearchType.valueOf(searchType.toUpperCase());
+        OrderStatus status = null;
+
+        if ((type == OrderSearchType.BY_STATUS || type == OrderSearchType.BY_ITEM_AND_STATUS) &&
+                (!StringUtils.hasText(orderStatus) || !OrderStatus.isValid(orderStatus))) {
+            throw new CustomException(ErrorType.INVALID_ORDER_SORT_CONDITION);
+        }
+
+        if (type == OrderSearchType.BY_STATUS || type == OrderSearchType.BY_ITEM_AND_STATUS) {
+            status = OrderStatus.valueOf(orderStatus.toUpperCase());
+        }
+
+        return new OrderCondition(type, itemId, status);
+    }
+
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderFindAllResponseDto.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderFindAllResponseDto.java
@@ -1,0 +1,24 @@
+package com.sparta.ezpzhost.domain.order.dto;
+
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import lombok.Getter;
+
+@Getter
+public class OrderFindAllResponseDto {
+
+    private Long orderId;
+    private int totalPrice;
+    private String orderStatus;
+    private String orderDate;
+
+    private OrderFindAllResponseDto(Order order) {
+        this.orderId = order.getId();
+        this.totalPrice = order.getTotalPrice();
+        this.orderStatus = order.getOrderStatus().toString();
+        this.orderDate = order.getCreatedAt().toLocalDate().toString();
+    }
+
+    public static OrderFindAllResponseDto of(Order order) {
+        return new OrderFindAllResponseDto(order);
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/dto/OrderResponseDto.java
@@ -1,0 +1,33 @@
+package com.sparta.ezpzhost.domain.order.dto;
+
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import com.sparta.ezpzhost.domain.order.enums.OrderStatus;
+import com.sparta.ezpzhost.domain.orderline.dto.OrderlineResponseDto;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class OrderResponseDto {
+
+    private Long orderId;
+    private int totalPrice;
+    private OrderStatus orderStatus;
+    private List<OrderlineResponseDto> orderedItems;
+
+    private OrderResponseDto(Long orderId, int totalPrice, OrderStatus orderStatus,
+            List<OrderlineResponseDto> orderedItems) {
+        this.orderId = orderId;
+        this.totalPrice = totalPrice;
+        this.orderStatus = orderStatus;
+        this.orderedItems = orderedItems;
+    }
+
+    public static OrderResponseDto of(Order order, List<OrderlineResponseDto> orderedItems) {
+        return new OrderResponseDto(
+                order.getId(),
+                order.getTotalPrice(),
+                order.getOrderStatus(),
+                orderedItems
+        );
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/entity/Order.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/entity/Order.java
@@ -1,0 +1,71 @@
+package com.sparta.ezpzhost.domain.order.entity;
+
+import com.sparta.ezpzhost.common.entity.Timestamped;
+import com.sparta.ezpzhost.domain.order.enums.OrderStatus;
+import com.sparta.ezpzhost.domain.orderline.entity.Orderline;
+import com.sparta.ezpzhost.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private int totalPrice;
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus orderStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Orderline> orderlineList = new ArrayList<>();
+
+    /**
+     * Order 생성자
+     *
+     * @param user 주문자
+     */
+    private Order(User user) {
+        this.user = user;
+    }
+
+    /**
+     * Order 정적 팩토리 메서드
+     *
+     * @param user 주문자
+     * @return
+     */
+    public static Order of(User user) {
+        return new Order(user);
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/enums/OrderSearchType.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/enums/OrderSearchType.java
@@ -1,0 +1,17 @@
+package com.sparta.ezpzhost.domain.order.enums;
+
+public enum OrderSearchType {
+    ALL,       // 전체 조회
+    BY_ITEM,    // 상품별 조회
+    BY_STATUS,       // 주문 상태별 조회
+    BY_ITEM_AND_STATUS;
+
+    public static boolean isValid(String type) {
+        for (OrderSearchType orderSearchType : OrderSearchType.values()) {
+            if (orderSearchType.name().equalsIgnoreCase(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/enums/OrderStatus.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/enums/OrderStatus.java
@@ -1,0 +1,18 @@
+package com.sparta.ezpzhost.domain.order.enums;
+
+public enum OrderStatus {
+    ALL,
+    ORDER_COMPLETED,   // 주문 완료
+    IN_TRANSIT,        // 배송 중
+    DELIVERED,         // 배송 완료
+    CANCELLED;         // 주문 취소
+
+    public static boolean isValid(String status) {
+        for (OrderStatus orderStatus : OrderStatus.values()) {
+            if (orderStatus.name().equalsIgnoreCase(status)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.ezpzhost.domain.order.repository;
+
+
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustom.java
@@ -3,11 +3,12 @@ package com.sparta.ezpzhost.domain.order.repository;
 import com.sparta.ezpzhost.domain.host.entity.Host;
 import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
 import com.sparta.ezpzhost.domain.order.entity.Order;
-
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderRepositoryCustom {
 
     Page<Order> findOrdersAllByStatus(OrderCondition cond, Pageable pageable, Host host);
+
+    Order findOrderWithDetails(Long orderId, Long hostId);
 }

--- a/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.sparta.ezpzhost.domain.order.repository;
+
+import com.sparta.ezpzhost.domain.host.entity.Host;
+import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
+import com.sparta.ezpzhost.domain.order.entity.Order;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
+
+public interface OrderRepositoryCustom {
+
+    Page<Order> findOrdersAllByStatus(OrderCondition cond, Pageable pageable, Host host);
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -1,8 +1,10 @@
 package com.sparta.ezpzhost.domain.order.repository;
 
+import static com.sparta.ezpzhost.domain.host.entity.QHost.host;
 import static com.sparta.ezpzhost.domain.item.entity.QItem.item;
 import static com.sparta.ezpzhost.domain.order.entity.QOrder.order;
 import static com.sparta.ezpzhost.domain.orderline.entity.QOrderline.orderline;
+import static com.sparta.ezpzhost.domain.popup.entity.QPopup.popup;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
@@ -47,6 +49,19 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
                 .fetchOne();
 
         return PageableExecutionUtils.getPage(orders, pageable, () -> total);
+    }
+
+    @Override
+    public Order findOrderWithDetails(Long orderId, Long hostId) {
+        return jpaQueryFactory
+                .selectFrom(order)
+                .leftJoin(order.orderlineList, orderline).fetchJoin()  // Order와 Orderline을 조인
+                .leftJoin(orderline.item, item)  // Orderline과 Item을 조인
+                .leftJoin(item.popup, popup)  // Item과 Popup을 조인
+                .leftJoin(popup.host, host) // Popup과 Host를 조인
+                .where(order.id.eq(orderId)  // Order ID를 필터
+                        .and(host.id.eq(hostId)))  // Host ID를 필터
+                .fetchOne();
     }
 
     private BooleanExpression orderStatusEq(OrderStatus status) {

--- a/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -1,0 +1,77 @@
+package com.sparta.ezpzhost.domain.order.repository;
+
+import static com.sparta.ezpzhost.domain.item.entity.QItem.item;
+import static com.sparta.ezpzhost.domain.order.entity.QOrder.order;
+import static com.sparta.ezpzhost.domain.orderline.entity.QOrderline.orderline;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.ezpzhost.domain.host.entity.Host;
+import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import com.sparta.ezpzhost.domain.order.enums.OrderSearchType;
+import com.sparta.ezpzhost.domain.order.enums.OrderStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Order> findOrdersAllByStatus(OrderCondition cond, Pageable pageable, Host host) {
+        List<Order> orders = jpaQueryFactory.selectFrom(order)
+                .leftJoin(orderline).on(order.id.eq(orderline.order.id))
+                .leftJoin(orderline.item, item)
+                .where(
+                        item.popup.host.eq(host),
+                        searchTypeEq(cond)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory.select(Wildcard.count)
+                .from(order)
+                .leftJoin(orderline).on(order.id.eq(orderline.order.id))
+                .leftJoin(orderline.item, item)
+                .where(
+                        item.popup.host.eq(host),
+                        searchTypeEq(cond)
+                )
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(orders, pageable, () -> total);
+    }
+
+    private BooleanExpression orderStatusEq(OrderStatus status) {
+        if (status == null || status == OrderStatus.ALL) {
+            return null;
+        }
+        return order.orderStatus.eq(status);
+    }
+
+    private BooleanExpression itemIdEq(Long itemId) {
+        if (itemId == null) {
+            return null;
+        }
+        return orderline.item.id.eq(itemId);
+    }
+
+    private BooleanExpression searchTypeEq(OrderCondition cond) {
+        if (cond.getSearchType() == OrderSearchType.BY_ITEM) {
+            return itemIdEq(cond.getItemId());
+        } else if (cond.getSearchType() == OrderSearchType.BY_STATUS) {
+            return orderStatusEq(cond.getOrderStatus());
+        } else if (cond.getSearchType() == OrderSearchType.BY_ITEM_AND_STATUS) {
+            return itemIdEq(cond.getItemId()).and(orderStatusEq(cond.getOrderStatus()));
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
@@ -36,7 +36,7 @@ public class OrderService {
      * @param host     요청한 호스트
      * @return 조회 조건에 따른 주문 목록
      */
-    public Page<OrderFindAllResponseDto> findOrdersAllByStatus(OrderCondition cond,
+    public Page<OrderFindAllResponseDto> findAllOrders(OrderCondition cond,
             Pageable pageable, Host host) {
         if (cond.getItemId() != -1) {
             Item item = itemRepository.findById(cond.getItemId())

--- a/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
@@ -7,8 +7,12 @@ import com.sparta.ezpzhost.domain.item.entity.Item;
 import com.sparta.ezpzhost.domain.item.repository.ItemRepository;
 import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
 import com.sparta.ezpzhost.domain.order.dto.OrderFindAllResponseDto;
+import com.sparta.ezpzhost.domain.order.dto.OrderResponseDto;
 import com.sparta.ezpzhost.domain.order.entity.Order;
 import com.sparta.ezpzhost.domain.order.repository.OrderRepository;
+import com.sparta.ezpzhost.domain.orderline.dto.OrderlineResponseDto;
+import com.sparta.ezpzhost.domain.orderline.repository.OrderlineRepository;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +26,7 @@ public class OrderService {
 
     private final OrderRepository orderRepository;
     private final ItemRepository itemRepository;
+    private final OrderlineRepository orderlineRepository;
 
     /**
      * 조건별 주문 목록 조회
@@ -42,5 +47,26 @@ public class OrderService {
         }
         Page<Order> orderPages = orderRepository.findOrdersAllByStatus(cond, pageable, host);
         return orderPages.map(OrderFindAllResponseDto::of);
+    }
+
+    /**
+     * 주문 상세 조회
+     *
+     * @param orderId 조회할 주문 id
+     * @param host    요청한 호스트
+     * @return 요청한 주문 상세 조회 데이터
+     */
+    public OrderResponseDto findOrder(Long orderId, Host host) {
+        Order order = orderRepository.findOrderWithDetails(orderId, host.getId());
+
+        if (order == null) {
+            throw new CustomException(ErrorType.ORDER_NOT_FOUND_OR_ACCESS_DENIED);
+        }
+
+        List<OrderlineResponseDto> orderlineResponseDtoList = order.getOrderlineList().stream()
+                .filter(orderline -> itemRepository.isItemSoldByHost(orderline.getItem().getId(),
+                        host.getId())).toList().stream().map(OrderlineResponseDto::of).toList();
+
+        return OrderResponseDto.of(order, orderlineResponseDtoList);
     }
 }

--- a/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/order/service/OrderService.java
@@ -1,0 +1,46 @@
+package com.sparta.ezpzhost.domain.order.service;
+
+import com.sparta.ezpzhost.common.exception.CustomException;
+import com.sparta.ezpzhost.common.exception.ErrorType;
+import com.sparta.ezpzhost.domain.host.entity.Host;
+import com.sparta.ezpzhost.domain.item.entity.Item;
+import com.sparta.ezpzhost.domain.item.repository.ItemRepository;
+import com.sparta.ezpzhost.domain.order.dto.OrderCondition;
+import com.sparta.ezpzhost.domain.order.dto.OrderFindAllResponseDto;
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import com.sparta.ezpzhost.domain.order.repository.OrderRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@AllArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ItemRepository itemRepository;
+
+    /**
+     * 조건별 주문 목록 조회
+     *
+     * @param cond     조회 조건
+     * @param pageable 페이지네이션 조건
+     * @param host     요청한 호스트
+     * @return 조회 조건에 따른 주문 목록
+     */
+    public Page<OrderFindAllResponseDto> findOrdersAllByStatus(OrderCondition cond,
+            Pageable pageable, Host host) {
+        if (cond.getItemId() != -1) {
+            Item item = itemRepository.findById(cond.getItemId())
+                    .orElseThrow(() -> new CustomException(ErrorType.ITEM_ACCESS_FORBIDDEN));
+            if (!item.getPopup().getHost().getId().equals(host.getId())) {
+                throw new CustomException(ErrorType.ITEM_ACCESS_FORBIDDEN);
+            }
+        }
+        Page<Order> orderPages = orderRepository.findOrdersAllByStatus(cond, pageable, host);
+        return orderPages.map(OrderFindAllResponseDto::of);
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/orderline/dto/OrderlineResponseDto.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/orderline/dto/OrderlineResponseDto.java
@@ -1,0 +1,26 @@
+package com.sparta.ezpzhost.domain.orderline.dto;
+
+import com.sparta.ezpzhost.domain.orderline.entity.Orderline;
+import lombok.Getter;
+
+@Getter
+public class OrderlineResponseDto {
+
+    private Long itemId;
+    private int quantity;
+    private int orderPrice;
+
+    private OrderlineResponseDto(Long itemId, int quantity, int orderPrice) {
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.orderPrice = orderPrice;
+    }
+
+    public static OrderlineResponseDto of(Orderline orderline) {
+        return new OrderlineResponseDto(
+                orderline.getItem().getId(),
+                orderline.getQuantity(),
+                orderline.getOrderPrice()
+        );
+    }
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/orderline/entity/Orderline.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/orderline/entity/Orderline.java
@@ -1,0 +1,68 @@
+package com.sparta.ezpzhost.domain.orderline.entity;
+
+import com.sparta.ezpzhost.domain.item.entity.Item;
+import com.sparta.ezpzhost.domain.order.entity.Order;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Orderline {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "orderline_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private int orderPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    /**
+     * Orderline 생성자
+     *
+     * @param quantity 주문할 상품의 수량
+     * @param order    주문
+     * @param item     주문할 상품
+     */
+    private Orderline(int quantity, Order order, Item item) {
+        this.quantity = quantity;
+        this.orderPrice = quantity * item.getPrice();
+        this.order = order;
+        this.item = item;
+    }
+
+    /**
+     * Orderline 정적 팩토리 메서드
+     *
+     * @param quantity 주문할 상품의 수량
+     * @param order    주문
+     * @param item     주문할 상품
+     * @return Orderline
+     */
+    public static Orderline of(int quantity, Order order, Item item) {
+        return new Orderline(quantity, order, item);
+    }
+
+
+}

--- a/src/main/java/com/sparta/ezpzhost/domain/orderline/repository/OrderlineRepository.java
+++ b/src/main/java/com/sparta/ezpzhost/domain/orderline/repository/OrderlineRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.ezpzhost.domain.orderline.repository;
+
+import com.sparta.ezpzhost.domain.orderline.entity.Orderline;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderlineRepository extends JpaRepository<Orderline, Long> {
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #18 

## 📝 작업 내용

> 주문 목록 조회, 주문 상세 조회

### 스크린샷 (선택)
- 주문 목록 조회(ALL)
![image](https://github.com/user-attachments/assets/16cd3327-8c9a-464f-945e-eb7dc7c1e47b)

- 주문 목록 조회(BY_ITEM, 조회할게 없을때)
![image](https://github.com/user-attachments/assets/88648135-9719-415c-8adc-ba3a271b764b)

- 주문 목록 조회(BY_ITEM, 조회할게 있을때)
![image](https://github.com/user-attachments/assets/cfb5c737-672b-4b0c-a1fb-da6cb95c9644)

- 주문 목록 조회(BY_STATUS, 조회할게 없을때)
![image](https://github.com/user-attachments/assets/d1b8bef0-756d-4dff-baab-02c6549ae572)

- 주문 목록 조회(BY_STATUS, 조회할게 있을때)
![image](https://github.com/user-attachments/assets/4c598440-e625-47db-9cc8-8b6dbd6d90e2)

- 주문 목록 조회(BY_ITEM_AND_STATUS, 조회할게 없을때)
![image](https://github.com/user-attachments/assets/64be345e-4dc1-4128-b051-a9fc3bc93e2b)

- 주문 목록 조회(BY_ITEM_AND_STATUS, 조회할게 있을때)
![image](https://github.com/user-attachments/assets/de46140a-decb-4291-9f6c-02a0ffc93182)

- 주문 상세 조회
![image](https://github.com/user-attachments/assets/687d8842-2f54-4b96-9871-0fb98ff00183)

## 💬 리뷰 요구사항(선택)

> 주문 목록 조회에서 ALL(조건없이 조회), BY_ITEM(상품별), BY_STATUS(주문 상태별), BY_ITEM_AND_STATUS(상품별+주문상태별) 로 구분해놨는데 더 좋은 방법이 있을까요? ... 로직이 너무 복잡해서 테스트하기도 어려울 것 같고 맞게 구현한 건지 모르겠습니다....